### PR TITLE
Fix search bar focusing

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -13,7 +13,9 @@ document.onkeypress = (e) => {
     search.classList.add('active');
 
   input.scrollIntoView();
-  input.focus();
+  setTimeout(function() {
+    input.focus();
+  }, 300);
 
   $('#search .close').onclick = () =>
     search.classList.remove('active');


### PR DESCRIPTION
Since we can't focus on an element during a CSS transition, we need to add a delay with the length of it.

There also might be a better way to do this, but I'm not really an experienced coder.